### PR TITLE
Re–use existing font-feature-settings declarations

### DIFF
--- a/test/fixtures/font-variant.css
+++ b/test/fixtures/font-variant.css
@@ -1,8 +1,20 @@
 selector {
   font-variant-numeric: tabular-nums;
   font-variant-caps: all-small-caps;
+}
+selector {
   font-variant: normal;
+}
+selector {
   font-variant: inherit;
+}
+selector {
   font-variant: all-small-caps oldstyle-nums;
+}
+selector {
+  font-feature-settings: "onum";
+  font-variant: all-small-caps;
+}
+selector {
   font-variant-position: normal;
 }

--- a/test/fixtures/font-variant.expected.css
+++ b/test/fixtures/font-variant.expected.css
@@ -1,14 +1,25 @@
 selector {
-  font-feature-settings: "tnum";
+  font-feature-settings: "tnum", "smcp", "c2sc";
   font-variant-numeric: tabular-nums;
-  font-feature-settings: "smcp", "c2sc";
   font-variant-caps: all-small-caps;
+}
+selector {
   font-feature-settings: normal;
   font-variant: normal;
+}
+selector {
   font-feature-settings: inherit;
   font-variant: inherit;
+}
+selector {
   font-feature-settings: "smcp", "c2sc", "onum";
   font-variant: all-small-caps oldstyle-nums;
+}
+selector {
+  font-feature-settings: "onum", "smcp", "c2sc";
+  font-variant: all-small-caps;
+}
+selector {
   font-feature-settings: normal;
   font-variant-position: normal;
 }


### PR DESCRIPTION
Declaration with:

```css
selector
{
   font-variant-numeric: tabular-nums;
   font-variant-caps: all-small-caps;
}
```

Produced two `font-feature-settings`, first one being overwritten by first one:

```css
selector
{
  font-feature-settings: "tnum"; /* has no effect */
  font-variant-numeric: tabular-nums;
  font-feature-settings: "smcp", "c2sc";
  font-variant-caps: all-small-caps;
}
```


Changed so that if rule already has a `font-feature-settings` ([defined in source CSS](https://github.com/marek-saji/postcss-font-variant/blob/a2a136f227ecc707e1d30955d4199c0795ebbced/test/fixtures/font-variant.css#L14-L17) or [created by postcss for some previous `font-variant-*`](https://github.com/marek-saji/postcss-font-variant/blob/a2a136f227ecc707e1d30955d4199c0795ebbced/test/fixtures/font-variant.css#L1-L4)), it gets [reused](https://github.com/marek-saji/postcss-font-variant/blob/a2a136f227ecc707e1d30955d4199c0795ebbced/test/fixtures/font-variant.expected.css).