### PR TITLE
Properly handle font-variant-position:normal

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ var fontVariantProperties = {
 
   "font-variant-position": {
     sub: "\"subs\"",
-    "super": "\"sups\""
+    "super": "\"sups\"",
+    normal: "\"subs\" off, \"sups\" off"
   },
 
   "font-variant-caps": {
@@ -50,7 +51,9 @@ var fontVariantProperties = {
 for (var prop in fontVariantProperties) {
   var keys = fontVariantProperties[prop]
   for (var key in keys) {
-    fontVariantProperties["font-variant"][key] = keys[key]
+    if (!(key in fontVariantProperties["font-variant"])) {
+      fontVariantProperties["font-variant"][key] = keys[key]
+    }
   }
 }
 

--- a/test/fixtures/font-variant.expected.css
+++ b/test/fixtures/font-variant.expected.css
@@ -20,6 +20,6 @@ selector {
   font-variant: all-small-caps;
 }
 selector {
-  font-feature-settings: normal;
+  font-feature-settings: "subs" off, "sups" off;
   font-variant-position: normal;
 }


### PR DESCRIPTION
It has been interpreted same as `font-variant: normal`, which is not the case:

- `font-variant: normal` resets all `font-variant-*`:

  https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant#Values

- `font-variant-position: normal` displays text as nighter subscript, nor superscript

  https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-position#Values