### PR TITLE
Existing identical font-feature-settings gets duplicated

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = postcss.plugin("postcss-font-variant", function() {
         if (fontFeatureSettings === null) {
           fontFeatureSettings = getFontFeatureSettingsPrevTo(decl);
         }
-        if (fontFeatureSettings.value) {
+        if (fontFeatureSettings.value && fontFeatureSettings.value !== newValue) {
           fontFeatureSettings.value += ", " + newValue;
         }
         else {

--- a/test/fixtures/font-variant.css
+++ b/test/fixtures/font-variant.css
@@ -6,6 +6,10 @@ selector {
   font-variant: normal;
 }
 selector {
+  font-feature-settings: normal;
+  font-variant: normal;
+}
+selector {
   font-variant: inherit;
 }
 selector {

--- a/test/fixtures/font-variant.expected.css
+++ b/test/fixtures/font-variant.expected.css
@@ -8,6 +8,10 @@ selector {
   font-variant: normal;
 }
 selector {
+  font-feature-settings: normal;
+  font-variant: normal;
+}
+selector {
   font-feature-settings: inherit;
   font-variant: inherit;
 }


### PR DESCRIPTION
Currently, given CSS as follows:
```css
selector {
  font-feature-settings: normal;
  font-variant: normal;
}
```
The code produces the following after processing:
```css
selector {
  font-feature-settings: normal, normal;
  font-variant: normal;
}
```
This code makes sure that if there's an existing `font-feature-settings` value, the new value being appended doesn't match what currently exists.