### PR TITLE
Fix bug where font-variant-caps: small-caps resulted in c2sc feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ you will get:
 
 ```css
 h2 {
-  font-feature-settings: "c2sc";
+  font-feature-settings: "smcp";
   font-variant-caps: small-caps;
 }
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var fontVariantProperties = {
   },
 
   "font-variant-caps": {
-    "small-caps": "\"c2sc\"",
+    "small-caps": "\"smcp\"",
     "all-small-caps": "\"smcp\", \"c2sc\"",
     "petite-caps": "\"pcap\"",
     "all-petite-caps": "\"pcap\", \"c2pc\"",

--- a/test/fixtures/font-variant.css
+++ b/test/fixtures/font-variant.css
@@ -13,7 +13,7 @@ selector {
   font-variant: inherit;
 }
 selector {
-  font-variant: all-small-caps oldstyle-nums;
+  font-variant: small-caps oldstyle-nums;
 }
 selector {
   font-feature-settings: "onum";

--- a/test/fixtures/font-variant.expected.css
+++ b/test/fixtures/font-variant.expected.css
@@ -16,8 +16,8 @@ selector {
   font-variant: inherit;
 }
 selector {
-  font-feature-settings: "smcp", "c2sc", "onum";
-  font-variant: all-small-caps oldstyle-nums;
+  font-feature-settings: "smcp", "onum";
+  font-variant: small-caps oldstyle-nums;
 }
 selector {
   font-feature-settings: "onum", "smcp", "c2sc";


### PR DESCRIPTION
This fixes #14. I’ve never written a non-trivial amount of Javascript, and don’t have a Javascript environment on my machine – I just `grep`ped for `c2sc` and fixed it as best as I could. Please tell me if I’ve made any mistakes!